### PR TITLE
Don't show RSVP info & form on password-protected posts if the passwo…

### DIFF
--- a/includes/rsvpme_events_post_type.php
+++ b/includes/rsvpme_events_post_type.php
@@ -303,7 +303,7 @@ function rsvp_me_event_page($content){
 	global $post;
 	global $foomanchu;
 
-	if($post->post_type != "event" || !is_single($post) ) return $content;
+	if($post->post_type != "event" || !is_single($post) || post_password_required() ) return $content;
 
 	$fields = array(
 		'venue_name' => '', 


### PR DESCRIPTION
Changed `includes/rsvpme_events_post_type.php` so that password protected posts don't show RSVP information and form unless the correct password is entered.
